### PR TITLE
Support multiple args in capybara's original set

### DIFF
--- a/lib/tedium/capybara/node_element.rb
+++ b/lib/tedium/capybara/node_element.rb
@@ -6,14 +6,13 @@ module Tedium
         base.send(:alias_method, :set, :augmented_select)
       end
 
-      def augmented_select(value)
+      def augmented_select(*args)
         if tag_name == "select"
-          find(:option_with_value_or_label, value).select_option
+          find(:option_with_value_or_label, args[0]).select_option
         else
-          original_set(value)
+          original_set(*args)
         end
       end
     end
   end
 end
-


### PR DESCRIPTION
Fixing this issue:

```
Failure/Error: fill_in('Title', with: 'This the title')
     ArgumentError:
       wrong number of arguments (2 for 1)
     # /Users/ajjahn/.rvm/gems/ruby-2.1.3/gems/tedium-0.0.4/lib/tedium/capybara/node_element.rb:9:in `augmented_select'
     # /Users/ajjahn/.rvm/gems/ruby-2.1.3/gems/capybara-2.4.4/lib/capybara/node/actions.rb:56:in `fill_in'
     # /Users/ajjahn/.rvm/gems/ruby-2.1.3/gems/capybara-2.4.4/lib/capybara/session.rb:676:in `block (2 levels) in <class:Session>'
     # /Users/ajjahn/.rvm/gems/ruby-2.1.3/gems/capybara-2.4.4/lib/capybara/dsl.rb:51:in `block (2 levels) in <module:DSL>'
     # ./spec/features/apply_spec.rb:21:in `block (3 levels) in <top (required)>'
```
